### PR TITLE
use the right variable name in README.md, fix #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ and so shared across many computers.
 ### Using a non-default config location
 
 By default, desks live in `~/.desk/desks`. If you want to use some other location,
-specify as much in `desk init` and then ensure you set `$DESK_DIR` to match
+specify as much in `desk init` and then ensure you set `$DESK_DESKS_DIR` to match
 that location in your shell's rc file.
 
 ### Usage with OS X


### PR DESCRIPTION
after filing #4, @tompaton mentionned that I should set the **`$DESK_DESKS_DIR`** in my .bashrc, which seemed to me as the README mentions the **`$DESK_DIR`**.
A quick look at the [source code](https://github.com/jamesob/desk/blob/master/desk#L5) proved him right (thanks @tompaton !).

This PR updates the README.md file so that it uses the right variable name.
